### PR TITLE
Fixed bug relating to the changing of user role

### DIFF
--- a/src/views/UserManage.vue
+++ b/src/views/UserManage.vue
@@ -163,14 +163,18 @@ watch(
   [users, isUsersTabActive],
   ([newUsers, isUsersActive]) => {
     if (isUsersActive) {
-      // Logic specific to the "Users" tab
       newUsers.forEach((user) => {
-        if (
-          user.selectedRoleName &&
-          roleNameToIdMap.value[user.selectedRoleName] !== user.userRoleId
-        ) {
-          changedUserRoles.value[user.id] =
-            roleNameToIdMap.value[user.selectedRoleName];
+        const selectedRoleId = roleNameToIdMap.value[user.selectedRoleName];
+        if (selectedRoleId !== undefined) {
+          if (selectedRoleId === user.userRoleId) {
+            // If the selected role is the same as the original role, remove the change tracking for this user.
+            if (changedUserRoles.value.hasOwnProperty(user.id)) {
+              delete changedUserRoles.value[user.id];
+            }
+          } else {
+            // Track the role change.
+            changedUserRoles.value[user.id] = selectedRoleId;
+          }
         }
       });
     }


### PR DESCRIPTION
Fixed a bug that Solomon found where if you changed a user's role and then switched it back to their original role before saving and then clicked to save all changes, it would update the user's role with the role that you selected before changing it back to the original.